### PR TITLE
set_name() method for worksheet

### DIFF
--- a/lib/Excel/Writer/XLSX.pm
+++ b/lib/Excel/Writer/XLSX.pm
@@ -560,6 +560,7 @@ The following methods are available through a new worksheet:
     insert_chart()
     data_validation()
     get_name()
+    set_name()
     activate()
     select()
     hide()
@@ -1556,7 +1557,14 @@ The C<get_name()> method is used to retrieve the name of a worksheet. For exampl
         print $sheet->get_name();
     }
 
-For reasons related to the design of Excel::Writer::XLSX and to the internals of Excel there is no C<set_name()> method. The only way to set the worksheet name is via the C<add_worksheet()> method.
+
+
+
+=head2 set_name($name)
+
+The C<set_name()> method is used to set the name of a worksheet. For example:
+
+    $worksheet->set_name('My Worksheet');
 
 
 

--- a/lib/Excel/Writer/XLSX/Worksheet.pm
+++ b/lib/Excel/Writer/XLSX/Worksheet.pm
@@ -297,6 +297,21 @@ sub get_name {
 
 ###############################################################################
 #
+# set_name().
+#
+# Set the worksheet name.
+#
+sub set_name {
+
+    my $self = shift;
+    my $name = shift;
+
+    $self->{_name} = $name;
+}
+
+
+###############################################################################
+#
 # select()
 #
 # Set this worksheet as a selected worksheet, i.e. the worksheet has its tab

--- a/t/workbook/workbook_04.t
+++ b/t/workbook/workbook_04.t
@@ -1,0 +1,55 @@
+###############################################################################
+#
+# Tests for Excel::Writer::XLSX::Workbook methods.
+#
+# reverse('(c)'), September 2010, John McNamara, jmcnamara@cpan.org
+#
+
+use lib 't/lib';
+use TestFunctions qw(_expected_to_aref _got_to_aref _is_deep_diff _new_workbook);
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+
+###############################################################################
+#
+# Tests setup.
+#
+my $expected;
+my $got;
+my $caption;
+my $workbook;
+
+
+###############################################################################
+#
+# Test the _assemble_xml_file() method.
+#
+$caption = " \tWorkbook: _assemble_xml_file()";
+
+$workbook = _new_workbook(\$got);
+$workbook->add_worksheet('First Sheet');
+$workbook->add_worksheet('Some Name')->set_name('Another Name');
+$workbook->_assemble_xml_file();
+
+$expected = _expected_to_aref();
+$got      = _got_to_aref( $got );
+
+_is_deep_diff( $got, $expected, $caption );
+
+__DATA__
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <fileVersion appName="xl" lastEdited="4" lowestEdited="4" rupBuild="4505"/>
+  <workbookPr defaultThemeVersion="124226"/>
+  <bookViews>
+    <workbookView xWindow="240" yWindow="15" windowWidth="16095" windowHeight="9660"/>
+  </bookViews>
+  <sheets>
+    <sheet name="First Sheet" sheetId="1" r:id="rId1"/>
+    <sheet name="Another Name" sheetId="2" r:id="rId2"/>
+  </sheets>
+  <calcPr calcId="124519"/>
+</workbook>


### PR DESCRIPTION
The documentation says:

"For reasons related to the design of Excel::Writer::XLSX and to the internals of Excel there is no set_name() method. The only way to set the worksheet name is via the add_worksheet() method."

However, adding a simple set_name method seems to work fine.  Does the above comment still apply?  Is there anything problematic about this commit?
