### PR TITLE
Excel::Writer::XLSX::add_table version(0.68) omits zeros (#65)

### DIFF
--- a/lib/Excel/Writer/XLSX/Worksheet.pm
+++ b/lib/Excel/Writer/XLSX/Worksheet.pm
@@ -4015,7 +4015,7 @@ sub add_table {
 
                 my $token = $data->[$i]->[$j];
 
-                if ( $token ) {
+                if (defined $token ) {
                     $self->write( $row, $col, $token, $col_formats[$j] );
                 }
 


### PR DESCRIPTION
fix the issue that 0 are not printed in table
