### PR TITLE
Bug fix for write() module in Worksheet.pm

### DIFF
--- a/lib/Excel/Writer/XLSX/Worksheet.pm
+++ b/lib/Excel/Writer/XLSX/Worksheet.pm
@@ -1824,6 +1824,7 @@ sub write {
     }
 
     my $token = $_[2];
+    my $format = $_[3];
 
     # Handle undefs as blanks
     $token = '' unless defined $token;
@@ -1852,7 +1853,9 @@ sub write {
     }
 
     # Match number
-    elsif ( $token =~ /^([+-]?)(?=\d|\.\d)\d*(\.\d*)?([Ee]([+-]?\d+))?$/ ) {
+    elsif ( $token =~ /^([+-]?)(?=\d|\.\d)\d*(\.\d*)?([Ee]([+-]?\d+))?$/
+            and ($token + 0) !~ /inf/
+            and (not defined ${$format}{_num_format} or ${$format}{_num_format} ne "@") ) {
         return $self->write_number( @_ );
     }
 


### PR DESCRIPTION
Change so that write() will not call write_number() when the value is too large for Perl to handle or when the format has been set to text (@).

I came across this when calling write_row() and one of the fields is a Secondary Number (like Apt #). Some of the information is in the format of '2E310' which write() treats as a scientific number, but it is too big for Perl so write_number() ends up making it an 'Infinity'.

I also added code so that write() won't call write_number() if the format has been set to text (@). I thought of this since the above fix really just happens to fix my issue as the "number" is so large. It doesn't fix cases like '2E10' that aren't too big. I would expect that if I set a format to text then it will be written as text not as a number.
