### PR TITLE
Fix calcPr to avoid false save file prompt

### DIFF
--- a/lib/Excel/Writer/XLSX/Workbook.pm
+++ b/lib/Excel/Writer/XLSX/Workbook.pm
@@ -2208,12 +2208,11 @@ sub _write_sheet {
 sub _write_calc_pr {
 
     my $self            = shift;
-    my $calc_id         = 124519;
+    my $calc_id         = 125725;
     my $concurrent_calc = 0;
 
     my @attributes = (
         'calcId'         => $calc_id,
-        'fullCalcOnLoad' => 1
     );
 
     $self->xml_empty_tag( 'calcPr', @attributes );

--- a/t/workbook/sub_write_calc_pr.t
+++ b/t/workbook/sub_write_calc_pr.t
@@ -28,7 +28,7 @@ my $workbook;
 # Test the _write_calc_pr() method.
 #
 $caption  = " \tWorkbook: _write_calc_pr()";
-$expected = '<calcPr calcId="124519" fullCalcOnLoad="1"/>';
+$expected = '<calcPr calcId="125725"/>';
 
 $workbook = _new_workbook(\$got);
 

--- a/t/workbook/workbook_01.t
+++ b/t/workbook/workbook_01.t
@@ -49,6 +49,6 @@ __DATA__
   <sheets>
     <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
   </sheets>
-  <calcPr calcId="124519" fullCalcOnLoad="1"/>
+  <calcPr calcId="125725"/>
 </workbook>
 

--- a/t/workbook/workbook_02.t
+++ b/t/workbook/workbook_02.t
@@ -51,5 +51,5 @@ __DATA__
     <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
     <sheet name="Sheet2" sheetId="2" r:id="rId2"/>
   </sheets>
-  <calcPr calcId="124519" fullCalcOnLoad="1"/>
+  <calcPr calcId="125725"/>
 </workbook>

--- a/t/workbook/workbook_03.t
+++ b/t/workbook/workbook_03.t
@@ -51,5 +51,5 @@ __DATA__
     <sheet name="Non Default Name" sheetId="1" r:id="rId1"/>
     <sheet name="Another Name" sheetId="2" r:id="rId2"/>
   </sheets>
-  <calcPr calcId="124519" fullCalcOnLoad="1"/>
+  <calcPr calcId="125725"/>
 </workbook>


### PR DESCRIPTION
This commit changes the calcId from 124519 to 125725 and removes the
'fullCalcOnLoad' attribute to avoid save file propmt when user exits
with no changes. This issue was reported as issue #100. The new calcId
is extracted from Excel file generated by Excel 2007 (12.0.6683.5002)
SP3 MSO (12.0.6683.5000). This fix may not work with Excel versions
later than 2007.
