### PR TITLE
Revert "Add set_calc_mode() to set calcMode and calcId"

### DIFF
--- a/lib/Excel/Writer/XLSX/Workbook.pm
+++ b/lib/Excel/Writer/XLSX/Workbook.pm
@@ -100,10 +100,6 @@ sub new {
     $self->{_str_table}  = {};
     $self->{_str_array}  = [];
 
-    # formula calculation default settings
-    $self->{_calc_id}   = 124519;
-    $self->{_calc_mode} = 0;
-
 
     bless $self, $class;
 
@@ -2205,25 +2201,6 @@ sub _write_sheet {
 
 ###############################################################################
 #
-# set_calc_mode()
-#
-# Set calculation mode and optionally calcId.
-# Args:
-#       mode: String containing one of:
-#           * auto
-#           * autoNoTable
-#           * manual
-#       calc_id: calcId known to Excel
-#
-sub set_calc_mode {
-    my($self, $mode, $calc_id) = @_;
-
-    $self->{_calc_mode} = $mode;
-    $self->{_calc_id}   = $calc_id if defined($calc_id);
-}
-
-###############################################################################
-#
 # _write_calc_pr()
 #
 # Write <calcPr> element.
@@ -2231,18 +2208,13 @@ sub set_calc_mode {
 sub _write_calc_pr {
 
     my $self            = shift;
+    my $calc_id         = 124519;
+    my $concurrent_calc = 0;
 
     my @attributes = (
-        calcId         => $self->{_calc_id},
-        calcOnSave     => 0
+        'calcId'         => $calc_id,
+        'fullCalcOnLoad' => 1
     );
-
-    if ($self->{_calc_mode} eq 'manual') {
-        push @attributes, calcMode => 'manual';
-    }
-    elsif ($self->{_calc_mode} eq 'autoNoTable') {
-        push @attributes, calcMode => 'autoNoTable';
-    }
 
     $self->xml_empty_tag( 'calcPr', @attributes );
 }

--- a/t/workbook/sub_write_calc_pr.t
+++ b/t/workbook/sub_write_calc_pr.t
@@ -10,7 +10,7 @@ use TestFunctions '_new_workbook';
 use strict;
 use warnings;
 
-use Test::More tests => 4;
+use Test::More tests => 1;
 
 
 ###############################################################################
@@ -28,52 +28,10 @@ my $workbook;
 # Test the _write_calc_pr() method.
 #
 $caption  = " \tWorkbook: _write_calc_pr()";
-$expected = '<calcPr calcId="124519" calcOnSave="0"/>';
+$expected = '<calcPr calcId="124519" fullCalcOnLoad="1"/>';
 
 $workbook = _new_workbook(\$got);
 
-$workbook->_write_calc_pr();
-
-is( $got, $expected, $caption );
-
-###############################################################################
-#
-# Test the _write_calc_pr() method w/ non-default calcId.
-#
-$caption  = " \tWorkbook: _write_calc_pr() non-default calcId";
-$expected = '<calcPr calcId="125725" calcOnSave="0"/>';
-
-$workbook = _new_workbook(\$got);
-
-$workbook->set_calc_mode('auto', 125725);
-$workbook->_write_calc_pr();
-
-is( $got, $expected, $caption );
-
-###############################################################################
-#
-# Test the _write_calc_pr() method w/ manual calculation
-#
-$caption  = " \tWorkbook: _write_calc_pr() manual calcId";
-$expected = '<calcPr calcId="124519" calcOnSave="0" calcMode="manual"/>';
-
-$workbook = _new_workbook(\$got);
-
-$workbook->set_calc_mode('manual');
-$workbook->_write_calc_pr();
-
-is( $got, $expected, $caption );
-
-###############################################################################
-#
-# Test the _write_calc_pr() method w/ autoNoTable calculation
-#
-$caption  = " \tWorkbook: _write_calc_pr() autoNoTable";
-$expected = '<calcPr calcId="124519" calcOnSave="0" calcMode="autoNoTable"/>';
-
-$workbook = _new_workbook(\$got);
-
-$workbook->set_calc_mode('autoNoTable');
 $workbook->_write_calc_pr();
 
 is( $got, $expected, $caption );

--- a/t/workbook/workbook_01.t
+++ b/t/workbook/workbook_01.t
@@ -49,6 +49,6 @@ __DATA__
   <sheets>
     <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
   </sheets>
-  <calcPr calcId="124519" calcOnSave="0"/>
+  <calcPr calcId="124519" fullCalcOnLoad="1"/>
 </workbook>
 

--- a/t/workbook/workbook_02.t
+++ b/t/workbook/workbook_02.t
@@ -51,5 +51,5 @@ __DATA__
     <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
     <sheet name="Sheet2" sheetId="2" r:id="rId2"/>
   </sheets>
-  <calcPr calcId="124519" calcOnSave="0"/>
+  <calcPr calcId="124519" fullCalcOnLoad="1"/>
 </workbook>

--- a/t/workbook/workbook_03.t
+++ b/t/workbook/workbook_03.t
@@ -51,5 +51,5 @@ __DATA__
     <sheet name="Non Default Name" sheetId="1" r:id="rId1"/>
     <sheet name="Another Name" sheetId="2" r:id="rId2"/>
   </sheets>
-  <calcPr calcId="124519" calcOnSave="0"/>
+  <calcPr calcId="124519" fullCalcOnLoad="1"/>
 </workbook>


### PR DESCRIPTION
Reverts jmcnamara/excel-writer-xlsx#104

I should have checked the previous PR more closely before merging since it turned `fullCalcOnLoad` off by default, thereby breaking backward compatibility.

I'm reverting this change and will re-implement the feature correctly.
