### PR TITLE
Stable timestamps

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,6 +10,7 @@ my %deps = (
     'Archive::Zip' => 1.30,
     'IO::File'     => 1.14,
     'File::Temp'   => 0.19,
+    'Time::Local'  => 0,
 );
 
 my %resources = (

--- a/lib/Excel/Writer/XLSX.pm
+++ b/lib/Excel/Writer/XLSX.pm
@@ -448,15 +448,19 @@ The properties that can be set are:
     title
     subject
     author
+    last_author
     manager
     company
     category
     keywords
     comments
+    created
     status
     hyperlink_base
 
 See also the C<properties.pl> program in the examples directory of the distro.
+Note that the C<created> property must be an array reference which matches the
+return values of L<perlfunc/gmtime> in list context, e.g. C<< created => [ gmtime() ] >>.
 
 
 

--- a/lib/Excel/Writer/XLSX/Workbook.pm
+++ b/lib/Excel/Writer/XLSX/Workbook.pm
@@ -23,6 +23,7 @@ use File::Find;
 use File::Temp qw(tempfile);
 use File::Basename 'fileparse';
 use Archive::Zip;
+use Time::Local qw(timegm);
 use Excel::Writer::XLSX::Worksheet;
 use Excel::Writer::XLSX::Chartsheet;
 use Excel::Writer::XLSX::Format;
@@ -1092,10 +1093,18 @@ sub _store_workbook {
     );
 
     # Store the xlsx component files with the temp dir name removed.
+    my @created_time = @{ $self->{_doc_properties}->{created} || $self->{_createtime} };
+    my $created_time = timegm(@created_time);
+
     for my $filename ( @xlsx_files ) {
         my $short_name = $filename;
         $short_name =~ s{^\Q$tempdir\E/?}{};
-        $zip->addFile( $filename, $short_name );
+        my $member = $zip->addFile( $filename, $short_name );
+
+        # Set zip member timestamps to match the workbook's timestamp, so that
+        # when the workbook's "created" property is set, the generated .xlsx
+        # file is byte-for-byte the same given the same inputs.
+        $member->setLastModFileDateTimeFromUnix( $created_time );
     }
 
 


### PR DESCRIPTION
One doc change for `set_properties` and a behaviour change when packaging up the zip file to set zip file member timestamps.

The commit messages explain the rationale.
