### PR TITLE
Adding simple font attributes to comments

### DIFF
--- a/lib/Excel/Writer/XLSX.pm
+++ b/lib/Excel/Writer/XLSX.pm
@@ -1416,6 +1416,8 @@ Most of these options are quite specific and in general the default comment beha
     start_col
     x_offset
     y_offset
+    font
+    font_size
 
 
 =over 4
@@ -1513,6 +1515,18 @@ This option is used to change the x offset, in pixels, of a comment within a cel
 This option is used to change the y offset, in pixels, of a comment within a cell:
 
     $worksheet->write_comment('C3', $comment, x_offset => 30);
+
+=item Option: font
+
+This option is used to change the font used in the comment from 'Tahoma' which is the default.
+
+    $worksheet->write_comment('C3', $comment, font => 'Calibri');
+
+=item Option: font_size
+
+This option is used to change the font size used in the comment from 8 which is the default.
+
+    $worksheet->write_comment('C3', $comment, font_size => 20);
 
 
 =back

--- a/lib/Excel/Writer/XLSX/Package/Comments.pm
+++ b/lib/Excel/Writer/XLSX/Package/Comments.pm
@@ -176,13 +176,15 @@ sub _write_comment_list {
         my $col    = $comment->[1];
         my $text   = $comment->[2];
         my $author = $comment->[3];
+        my $font   = $comment->[7];
+        my $size   = $comment->[8];
 
         # Look up the author id.
         my $author_id = undef;
         $author_id = $self->{_author_ids}->{$author} if defined $author;
 
         # Write the comment element.
-        $self->_write_comment( $row, $col, $text, $author_id );
+        $self->_write_comment( $row, $col, $text, $author_id, $font, $size );
     }
 
     $self->xml_end_tag( 'commentList' );
@@ -203,6 +205,8 @@ sub _write_comment {
     my $text      = shift;
     my $author_id = shift;
     my $ref       = xl_rowcol_to_cell( $row, $col );
+    my $font      = shift;
+    my $size      = shift;
 
     my @attributes = ( 'ref' => $ref );
 
@@ -212,7 +216,7 @@ sub _write_comment {
     $self->xml_start_tag( 'comment', @attributes );
 
     # Write the text element.
-    $self->_write_text( $text );
+    $self->_write_text( $text, [$font, $size] );
 
 
     $self->xml_end_tag( 'comment' );
@@ -229,11 +233,12 @@ sub _write_text {
 
     my $self = shift;
     my $text = shift;
+    my $fmt  = shift;
 
     $self->xml_start_tag( 'text' );
 
     # Write the text r element.
-    $self->_write_text_r( $text );
+    $self->_write_text_r( $text, $fmt );
 
     $self->xml_end_tag( 'text' );
 }
@@ -249,11 +254,12 @@ sub _write_text_r {
 
     my $self = shift;
     my $text = shift;
+    my $fmt  = shift;
 
     $self->xml_start_tag( 'r' );
 
     # Write the rPr element.
-    $self->_write_r_pr();
+    $self->_write_r_pr($fmt);
 
     # Write the text r element.
     $self->_write_text_t( $text );
@@ -292,17 +298,18 @@ sub _write_text_t {
 sub _write_r_pr {
 
     my $self = shift;
+    my $fmt  = shift;
 
     $self->xml_start_tag( 'rPr' );
 
     # Write the sz element.
-    $self->_write_sz();
+    $self->_write_sz($fmt->[1]);
 
     # Write the color element.
     $self->_write_color();
 
     # Write the rFont element.
-    $self->_write_r_font();
+    $self->_write_r_font($fmt->[0]);
 
     # Write the family element.
     $self->_write_family();
@@ -320,7 +327,7 @@ sub _write_r_pr {
 sub _write_sz {
 
     my $self = shift;
-    my $val  = 8;
+    my $val  = shift || 8;
 
     my @attributes = ( 'val' => $val );
 
@@ -354,7 +361,7 @@ sub _write_color {
 sub _write_r_font {
 
     my $self = shift;
-    my $val  = 'Tahoma';
+    my $val  = shift || 'Tahoma';
 
     my @attributes = ( 'val' => $val );
 

--- a/lib/Excel/Writer/XLSX/Worksheet.pm
+++ b/lib/Excel/Writer/XLSX/Worksheet.pm
@@ -6071,6 +6071,8 @@ sub _comment_params {
         x_scale    => 1,
         y_offset   => undef,
         y_scale    => 1,
+        font       => 'Tahoma',
+        font_size  => 8,
     );
 
 
@@ -6198,7 +6200,10 @@ sub _comment_params {
         $params{visible},
         $params{color},
 
-        [@vertices]
+        [@vertices],
+
+        $params{font},
+        $params{font_size},
     );
 }
 

--- a/t/package/comments/comments_02.t
+++ b/t/package/comments/comments_02.t
@@ -1,0 +1,60 @@
+###############################################################################
+#
+# Tests for Excel::Writer::XLSX::Package::Comments methods.
+#
+# reverse ('(c)'), September 2010, John McNamara, jmcnamara@cpan.org
+#
+
+use lib 't/lib';
+use TestFunctions qw(_expected_to_aref _got_to_aref _is_deep_diff _new_object);
+use strict;
+use warnings;
+use Excel::Writer::XLSX::Package::Comments;
+
+use Test::More tests => 1;
+
+###############################################################################
+#
+# Tests setup.
+#
+my $expected;
+my $caption;
+my $got;
+my $obj = _new_object( \$got, 'Excel::Writer::XLSX::Package::Comments' );
+
+
+###############################################################################
+#
+# Test the _assemble_xml_file() method.
+#
+$caption = " \tComments: _assemble_xml_file()";
+
+$obj->_assemble_xml_file([ [ 1, 1, 'Some text', 'John', undef, 81, [ 2, 0, 4, 4, 143, 10, 128, 74 ], 'Calibri', 20 ] ] );
+
+$expected = _expected_to_aref();
+$got      = _got_to_aref( $got );
+
+_is_deep_diff( $got, $expected, $caption );
+
+__DATA__
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<comments xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <authors>
+    <author>John</author>
+  </authors>
+  <commentList>
+    <comment ref="B2" authorId="0">
+      <text>
+        <r>
+          <rPr>
+            <sz val="20"/>
+            <color indexed="81"/>
+            <rFont val="Calibri"/>
+            <family val="2"/>
+          </rPr>
+          <t>Some text</t>
+        </r>
+      </text>
+    </comment>
+  </commentList>
+</comments>


### PR DESCRIPTION
This pull request adds `font` and `font_size` as optional parameters to the `write_comment()` method.

## References

#188 