### PR TITLE
Allow empty string forumla value to force recalc.

### DIFF
--- a/lib/Excel/Writer/XLSX/Worksheet.pm
+++ b/lib/Excel/Writer/XLSX/Worksheet.pm
@@ -7382,7 +7382,10 @@ sub _write_cell {
     elsif ( $type eq 'f' ) {
 
         # Write a formula.
-        my $value = $cell->[3] || 0;
+
+        # Allowing empty string here to force spreadsheet applications
+        # to recalculate the formula value upon XLSX load!
+        my $value = $cell->[3] // 0;
 
         # Check if the formula value is a string.
         if (   $value


### PR DESCRIPTION
Defaulting to zero within formula value nodes results in spreadsheet applications initially displaying `0`.
This quick fix allows empty string to be specified, which results in proper calculation upon document open. 

I tested empty `<v>` nodes in Excel 365 and LibreOffice.

Thanks!