### PR TITLE
Only install AUTOLOAD methods if not existing

### DIFF
--- a/lib/Excel/Writer/XLSX/Format.pm
+++ b/lib/Excel/Writer/XLSX/Format.pm
@@ -763,24 +763,28 @@ sub AUTOLOAD {
         # For "set_property_color" methods
         $value = _get_color( $_[0] );
 
-        *{$AUTOLOAD} = sub {
-            my $self = shift;
+        if ( ! $self->can($AUTOLOAD) ) {
+            *{$AUTOLOAD} = sub {
+                my $self = shift;
 
-            $self->{$attribute} = _get_color( $_[0] );
-        };
+                $self->{$attribute} = _get_color( $_[0] );
+            };
+        }
     }
     else {
 
         $value = $_[0];
         $value = 1 if not defined $value;    # The default value is always 1
 
-        *{$AUTOLOAD} = sub {
-            my $self  = shift;
-            my $value = shift;
+        if ( ! $self->can($AUTOLOAD) ) {
+            *{$AUTOLOAD} = sub {
+                my $self  = shift;
+                my $value = shift;
 
-            $value = 1 if not defined $value;
-            $self->{$attribute} = $value;
-        };
+                $value = 1 if not defined $value;
+                $self->{$attribute} = $value;
+            };
+        }
     }
 
 


### PR DESCRIPTION
The comments above the patched code mentions to only install
methods if they did not exists.
Using the module via Inline::Perl5 from Perl6 gave warnings when
using code like `$format->set_align('vcenter')`, and with
complex enough xlsx files, badly formatted files.

This checks if a method is already installed and only installs it
otherwise.