### PR TITLE
fix regression in 1bf0068 when set_column() is called with $last_col==0

### DIFF
--- a/lib/Excel/Writer/XLSX/Worksheet.pm
+++ b/lib/Excel/Writer/XLSX/Worksheet.pm
@@ -691,7 +691,7 @@ sub set_column {
     }
 
     # Store the column data based on the first column. Padded for sorting.
-    $self->{_colinfo}->{ sprintf "%05d", $first_col } = [@data];
+    $self->{_colinfo}->{ sprintf "%05d", $first_col } = [ $first_col, $last_col, $width, $format, $hidden, $level ];
 
     # Store the column change to allow optimisations.
     $self->{_col_size_changed} = 1;


### PR DESCRIPTION
good day,
there seems to have been a regression introduced in 1bf0068 when calling `set_column()` with `$last_col` set to zero.

```
  my $workbook = Excel::Writer::XLSX->new( $fh );
  $worksheet->set_column( 1, 0, 35 ); # does not work
  $worksheet->set_column( 'B:B', 35 ); # works
  $worksheet->set_column( 1, 1, 35 ); # probably works but did not check
  $workbook->close();

```
the docs indicate that this syntax should still work, even though the A1 syntax is suggested. this seems to be a fairly simply fix, but please forgive me if i am overlooking some context or intent.

sorry i could not find a relevant unit test to update as all of the ones i looked at in `t/regression/set_column*` and `t/regression/xlsx_files/set_column*` seem to use the A1 syntax.

My automatically generated system details are as follows:
```
Perl version   : 5.028001
OS name        : linux
Module versions: (not all are required)
                 Excel::Writer::XLSX     	1.09
                 Spreadsheet::WriteExcel 	(not installed)
                 Archive::Zip            	1.68
                 XML::Writer             	0.900
                 IO::File                	1.45
                 File::Temp              	0.2311
```