### PR TITLE
Adjust make mydocs invocation to Perl without dot in @INC

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -50,7 +50,7 @@ WriteMakefile(%params);
 #
 sub MY::postamble {
     "mydocs:\n"
-      . "\tperl -Mblib examples/gen_examples_pod.pl examples "
+      . "\tperl -Mlib=lib examples/gen_examples_pod.pl ./examples "
       . "> lib/Excel/Writer/XLSX/Examples.pm\n\n"
       . "tags:\n"
 	  . "\trm -f TAGS\n"


### PR DESCRIPTION
After perl lost "." from @INC, "make mydocs" does not work:

~~~~
$ make mydocs
perl -Mblib examples/gen_examples_pod.pl examples > lib/Excel/Writer/XLSX/Examples.pm Can't locate examples/../lib/Excel/Writer/XLSX.pm in @INC (@INC contains: /home/test/fedora/perl-Excel-Writer-XLSX/Excel-Writer-XLSX-1.11/blib/arch /home/test/fedora/perl-Excel-Writer-XLSX/Excel-Writer-XLSX-1.11/blib/lib /usr/local/lib64/perl5/5.36 /usr/local/share/perl5/5.36 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at examples/gen_examples_pod.pl line 30. make: *** [Makefile:1096: mydocs] Error 2
~~~~

But running "make mydocs" before "make all" also failed because it assumed blib has already been created an populated:

~~~~
$ make mydocs
perl -Mblib examples/gen_examples_pod.pl examples > lib/Excel/Writer/XLSX/Examples.pm Cannot find blib even in /home/test/fedora/perl-Excel-Writer-XLSX/Excel-Writer-XLSX-1.11/../../../../.. BEGIN failed--compilation aborted.
~~~~

This patch fixes both these issues.