### PR TITLE
Pr261 using File::Path::Tiny

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,10 @@ perl:
   - "5.12"
   - "5.10"
   - "5.8"
+  - "5.26-shrplib"
+  - "5.24-shrplib"
+  - "5.22-shrplib"
+  - "5.20-shrplib"
+  - "5.18-shrplib"
 sudo: false
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,9 +7,10 @@ use warnings;
 require 5.008002;
 
 my %deps = (
-    'Archive::Zip' => 1.30,
-    'IO::File'     => 1.14,
-    'File::Temp'   => 0.19,
+    'Archive::Zip'     => 1.30,
+    'IO::File'         => 1.14,
+    'File::Temp'       => 0.19,
+    'File::Path::Tiny' => 0,
 );
 
 my %resources = (

--- a/examples/multithreaded1.pl
+++ b/examples/multithreaded1.pl
@@ -1,0 +1,117 @@
+#!/usr/bin/perl
+
+###############################################################################
+#
+# Example of multi-threaded workbook creation with Excel::Writer::XLSX.
+# In this example, each thread waits for a process-wide lock to do its own
+# clean-up after creating all the workbooks.
+#
+# Copyright 2000-2020, John McNamara, jmcnamara@cpan.org
+#
+
+use strict;
+use warnings;
+use Excel::Writer::XLSX;
+use Excel::Writer::XLSX::Utility;
+use threads;
+use threads::shared;
+
+###############################################################################
+#
+# Declare the shared variable $cleanup_lock_counter.
+#
+my $cleanup_lock_counter = 0;
+share $cleanup_lock_counter;
+
+###############################################################################
+#
+# Generate workbooks in multiple concurrent threads.
+#
+my %operators = (
+    addition       => '+',
+    subtraction    => '-',
+    multiplication => '*',
+    division       => '/',
+    exponentiation => '^',
+);
+while ( my ( $operation, $operator ) = each %operators ) {
+    threads->create(
+        make_runnable(
+            [ $operation, $operator, 400, 400 ],
+            [ $operation, $operator, 420, 420 ],
+        )
+    );
+}
+$_->join foreach threads->list();
+
+###############################################################################
+#
+# Create the runnable for a thread to generate workbook files
+# and destroy its temporary files in a controlled manner.
+#
+sub make_runnable {
+    my @instructions = @_;
+    sub {
+
+        {    # increment the shared variable $cleanup_lock_counter.
+            lock $cleanup_lock_counter;
+            ++$cleanup_lock_counter;
+        }
+
+        # Make the workbooks and store the workbook objects.
+        my @workbookObjects = map { make_workbook(@$_); } @instructions;
+
+        {    # decrement the shared variable $cleanup_lock_counter.
+            lock $cleanup_lock_counter;
+            --$cleanup_lock_counter;
+            cond_signal $cleanup_lock_counter;
+        }
+
+        # Once $cleanup_lock_counter is 0, destroy temporary files.
+        lock $cleanup_lock_counter;
+        cond_wait $cleanup_lock_counter while $cleanup_lock_counter > 0;
+        $_->DESTROY foreach @workbookObjects;
+        cond_signal $cleanup_lock_counter;
+
+    };
+}
+
+###############################################################################
+#
+# Create a Excel::Writer::XLSX file.
+#
+sub make_workbook {
+
+    my ( $operation, $operator, $num_rows, $num_cols ) = @_;
+    my $long_name = "Table of $operation ($num_rows by $num_cols)";
+    my $workbook  = Excel::Writer::XLSX->new("$long_name.xlsx") or return;
+    my $worksheet = $workbook->add_worksheet( ucfirst($operation) );
+    $worksheet->hide_gridlines(2);
+    my $title_format =
+      $workbook->add_format( size => 15, bold => 1, num_format => '@' );
+    my $header_format = $workbook->add_format( bg_color => 46 );
+    $worksheet->write( 0, 0, $long_name, $title_format );
+    $worksheet->write( 2, 0, $operator,  $header_format );
+
+    $worksheet->write( $_ + 2, 0,  $_, $header_format ) foreach 1 .. $num_rows;
+    $worksheet->write( 2,      $_, $_, $header_format ) foreach 1 .. $num_cols;
+
+    foreach my $row ( 3 .. ( 2 + $num_rows ) ) {
+        foreach my $col ( 1 .. $num_cols ) {
+            $worksheet->write( $row, $col,
+                    '='
+                  . xl_rowcol_to_cell( $row, 0, 0, 1 )
+                  . $operator
+                  . xl_rowcol_to_cell( 2, $col, 1, 0 ) );
+        }
+    }
+
+    # Generate file.
+    $workbook->close();
+
+    # Return workbook object to caller, to control clean-up of temporary files.
+    $workbook;
+
+}
+
+__END__

--- a/examples/multithreaded2.pl
+++ b/examples/multithreaded2.pl
@@ -1,0 +1,126 @@
+#!/usr/bin/perl
+
+###############################################################################
+#
+# Example of multi-threaded workbook creation with Excel::Writer::XLSX.
+# In this example, each thread waits for a process-wide lock to do its own
+# clean-up after creating each workbook.
+#
+# Copyright 2000-2020, John McNamara, jmcnamara@cpan.org
+#
+
+use strict;
+use warnings;
+use Excel::Writer::XLSX;
+use Excel::Writer::XLSX::Utility;
+use threads;
+use threads::shared;
+
+###############################################################################
+#
+# Declare the shared variable $cleanup_lock_counter.
+#
+my $cleanup_lock_counter = 0;
+share $cleanup_lock_counter;
+
+###############################################################################
+#
+# Generate workbooks in multiple concurrent threads.
+#
+my %operators = (
+    addition       => '+',
+    subtraction    => '-',
+    multiplication => '*',
+    division       => '/',
+    exponentiation => '^',
+);
+while ( my ( $operation, $operator ) = each %operators ) {
+    threads->create(
+        make_runnable(
+            [ $operation, $operator, 400, 400 ],
+            [ $operation, $operator, 420, 420 ],
+        )
+    );
+}
+$_->join foreach threads->list();
+
+###############################################################################
+#
+# Create the runnable for a thread to generate workbook files.
+#
+sub make_runnable {
+    my @instructions = @_;
+    sub {
+        make_workbook_and_clean_up(@$_) foreach @instructions;
+    };
+}
+
+###############################################################################
+#
+# Wrapper around make_workbook to manage temporary file cleanup.
+#
+sub make_workbook_and_clean_up {
+    my ( $operation, $operator, $num_rows, $num_cols ) = @_;
+
+    {    # increment the shared variable $cleanup_lock_counter.
+        lock $cleanup_lock_counter;
+        ++$cleanup_lock_counter;
+    }
+
+    # Make the workbook and store the workbook object.
+    my $workbookObject =
+      make_workbook( $operation, $operator, $num_rows, $num_cols );
+
+    {    # decrement the shared variable $cleanup_lock_counter.
+        lock $cleanup_lock_counter;
+        --$cleanup_lock_counter;
+        cond_signal $cleanup_lock_counter;
+    }
+
+    # Once $cleanup_lock_counter is 0, destroy temporary files.
+    lock $cleanup_lock_counter;
+    cond_wait $cleanup_lock_counter while $cleanup_lock_counter > 0;
+    $workbookObject->DESTROY;
+    cond_signal $cleanup_lock_counter;
+
+}
+
+###############################################################################
+#
+# Create a Excel::Writer::XLSX file.
+#
+sub make_workbook {
+
+    my ( $operation, $operator, $num_rows, $num_cols ) = @_;
+    my $long_name = "Table of $operation ($num_rows by $num_cols)";
+    my $workbook  = Excel::Writer::XLSX->new("$long_name.xlsx") or return;
+    my $worksheet = $workbook->add_worksheet( ucfirst($operation) );
+    $worksheet->hide_gridlines(2);
+    my $title_format =
+      $workbook->add_format( size => 15, bold => 1, num_format => '@' );
+    my $header_format = $workbook->add_format( bg_color => 46 );
+    $worksheet->write( 0, 0, $long_name, $title_format );
+    $worksheet->write( 2, 0, $operator,  $header_format );
+
+    $worksheet->write( $_ + 2, 0,  $_, $header_format ) foreach 1 .. $num_rows;
+    $worksheet->write( 2,      $_, $_, $header_format ) foreach 1 .. $num_cols;
+
+    foreach my $row ( 3 .. ( 2 + $num_rows ) ) {
+        foreach my $col ( 1 .. $num_cols ) {
+            $worksheet->write( $row, $col,
+                    '='
+                  . xl_rowcol_to_cell( $row, 0, 0, 1 )
+                  . $operator
+                  . xl_rowcol_to_cell( 2, $col, 1, 0 ) );
+        }
+    }
+
+    # Generate file.
+    $workbook->close();
+
+    # Return workbook object to caller, to control clean-up of temporary files.
+    $workbook;
+
+}
+
+__END__

--- a/examples/multithreaded3.pl
+++ b/examples/multithreaded3.pl
@@ -1,0 +1,111 @@
+#!/usr/bin/perl
+
+###############################################################################
+#
+# Example of multi-threaded workbook creation with Excel::Writer::XLSX.
+# In this example, each thread cleans up manually its temporary storage after
+# creating each workbook.  The clean-up code in this example has not been
+# properly tested and relying on File::Temp's cleanup process with a lock
+# as in the other multithreaded examples would be safer.
+#
+# Copyright 2000-2020, John McNamara, jmcnamara@cpan.org
+#
+
+use strict;
+use warnings;
+use Excel::Writer::XLSX;
+use Excel::Writer::XLSX::Utility;
+use threads;
+
+###############################################################################
+#
+# Generate workbooks in multiple concurrent threads.
+#
+my %operators = (
+    addition       => '+',
+    subtraction    => '-',
+    multiplication => '*',
+    division       => '/',
+    exponentiation => '^',
+);
+while ( my ( $operation, $operator ) = each %operators ) {
+    threads->create(
+        make_runnable(
+            [ $operation, $operator, 400, 400 ],
+            [ $operation, $operator, 420, 420 ],
+        )
+    );
+}
+$_->join foreach threads->list();
+
+###############################################################################
+#
+# Create the runnable for a thread to generate workbook files
+# and destroy its temporary files in a controlled manner.
+#
+sub make_runnable {
+    my @instructions = @_;
+    sub {
+
+      # Make the workbooks and destroy the temporary files in a thread-safe way.
+        foreach (@instructions) {
+            my $workbook = make_workbook(@$_);
+            $workbook->{_tempdir_object}->unlink_on_destroy(0);
+            File::Find::find(
+                {
+                    wanted => sub {
+                        -f $_
+                          ? unlink $File::Find::name
+                          : rmdir $File::Find::name;
+                    },
+                    no_chdir        => 1,
+                    bydepth         => 1,
+                    untaint         => 1,
+                    untaint_pattern => qr|^(.+)$|
+                },
+                $workbook->{_tempdir_object}
+            );
+        }
+
+    };
+}
+
+###############################################################################
+#
+# Create a Excel::Writer::XLSX file.
+#
+sub make_workbook {
+
+    my ( $operation, $operator, $num_rows, $num_cols ) = @_;
+    my $long_name = "Table of $operation ($num_rows by $num_cols)";
+    my $workbook  = Excel::Writer::XLSX->new("$long_name.xlsx") or return;
+    my $worksheet = $workbook->add_worksheet( ucfirst($operation) );
+    $worksheet->hide_gridlines(2);
+    my $title_format =
+      $workbook->add_format( size => 15, bold => 1, num_format => '@' );
+    my $header_format = $workbook->add_format( bg_color => 46 );
+    $worksheet->write( 0, 0, $long_name, $title_format );
+    $worksheet->write( 2, 0, $operator,  $header_format );
+
+    $worksheet->write( $_ + 2, 0,  $_, $header_format ) foreach 1 .. $num_rows;
+    $worksheet->write( 2,      $_, $_, $header_format ) foreach 1 .. $num_cols;
+
+    foreach my $row ( 3 .. ( 2 + $num_rows ) ) {
+        foreach my $col ( 1 .. $num_cols ) {
+            $worksheet->write( $row, $col,
+                    '='
+                  . xl_rowcol_to_cell( $row, 0, 0, 1 )
+                  . $operator
+                  . xl_rowcol_to_cell( 2, $col, 1, 0 ) );
+        }
+    }
+
+    # Generate file.
+    $workbook->close();
+
+    # Return workbook object to caller, to control clean-up of temporary files.
+    $workbook;
+
+}
+
+__END__

--- a/lib/Excel/Writer/XLSX.pm
+++ b/lib/Excel/Writer/XLSX.pm
@@ -433,7 +433,7 @@ The reason for this is that Excel::Writer::XLSX relies on Perl's C<DESTROY> mech
 
 To avoid these issues it is recommended that you always close the Excel::Writer::XLSX filehandle using C<close()>.
 
-
+C<close()> is thread-safe but disposal of the Workbook object is not (because disposal of the Workbook object triggers the non-thread-safe destruction of temporary files by the C<File::Temp> module).  In a program in which several threads might be concurrently writing C<Excel::Writer::XLSX> files, the Workbook objects must only be destroyed or allowed to go out of scope within a critical code section that only one thread can be running at any one time.
 
 
 =head2 set_size( $width, $height )

--- a/lib/Excel/Writer/XLSX/Chart.pm
+++ b/lib/Excel/Writer/XLSX/Chart.pm
@@ -1354,6 +1354,8 @@ sub _get_gradient_properties {
 
     $gradient->{_colors} = $args->{colors};
 
+    $gradient->{_transparency} = $args->{transparency};
+
     if ( $args->{positions} ) {
 
         # Check the positions array has the right number of entries.
@@ -6857,7 +6859,9 @@ sub _write_a_gs_lst {
 
         # Write the a:srgbClr element.
         # TODO: Wait for a feature request to support transparency.
-        $self->_write_a_srgb_clr( $color );
+        $self->_write_a_srgb_clr( $color,
+            $gradient->{_transparency} ? $gradient->{_transparency}[$i] : ()
+        );
 
         $self->xml_end_tag( 'a:gs' );
     }

--- a/lib/Excel/Writer/XLSX/Chart/Bar.pm
+++ b/lib/Excel/Writer/XLSX/Chart/Bar.pm
@@ -81,11 +81,6 @@ sub combine {
     my $self  = shift;
     my $chart = shift;
 
-    if (!$chart->{_is_secondary}) {
-        carp 'Charts combined with Bar charts must be on a secondary axis';
-        return;
-    }
-
     $self->{_combined} = $chart;
 }
 

--- a/lib/Excel/Writer/XLSX/Workbook.pm
+++ b/lib/Excel/Writer/XLSX/Workbook.pm
@@ -298,6 +298,7 @@ sub DESTROY {
     local ( $@, $!, $^E, $? );
 
     $self->close() if not $self->{_fileclosed};
+    delete $self->{_tempdir_object};
 }
 
 
@@ -1129,6 +1130,13 @@ sub _store_workbook {
 
     my $self     = shift;
     my $tempdir  = File::Temp->newdir( DIR => $self->{_tempdir} );
+
+    # Store the File::Temp object within $self so that the temporary files
+    # are only removed when the workbook object is destroyed.
+    # This control over timing is required because the removal
+    # of File::Temp temporary directories is not thread-safe.
+    $self->{_tempdir_object} = $tempdir;
+
     my $packager = Excel::Writer::XLSX::Package::Packager->new();
     my $zip      = Archive::Zip->new();
 
@@ -1188,6 +1196,7 @@ sub _store_workbook {
     # Add the files to the zip archive. Due to issues with Archive::Zip in
     # taint mode we can't use addTree() so we have to build the file list
     # with File::Find and pass each one to addFile().
+    # The no_chdir option to File::Find::find is for thread safety.
     my @xlsx_files;
 
     my $wanted = sub { push @xlsx_files, $File::Find::name if -f };
@@ -1195,6 +1204,7 @@ sub _store_workbook {
     File::Find::find(
         {
             wanted          => $wanted,
+            no_chdir        => 1,
             untaint         => 1,
             untaint_pattern => qr|^(.+)$|
         },

--- a/t/regression/multithreaded01.t
+++ b/t/regression/multithreaded01.t
@@ -1,0 +1,139 @@
+###############################################################################
+#
+# Tests the output of Excel::Writer::XLSX against Excel generated files.
+# (multi-threaded variant)
+#
+# Copyright 2000-2020, John McNamara, jmcnamara@cpan.org
+#
+
+use lib 't/lib';
+use TestFunctions qw(_compare_xlsx_files _is_deep_diff);
+use strict;
+use warnings;
+
+my ( $numThreads, $numBooksPerThread );
+
+BEGIN {
+    $numThreads        = 6;
+    $numBooksPerThread = 7;
+}
+
+use Test::More;
+use Excel::Writer::XLSX;
+
+eval { require threads; require threads::shared };
+if ($@) {
+    plan skip_all => 'threads and threads::shared required to run these tests.';
+}
+else {
+    plan tests => $numThreads * $numBooksPerThread;
+}
+
+###############################################################################
+#
+# Tests setup.
+#
+my $filename     = "simple01.xlsx";
+my $dir          = 't/regression/';
+my $exp_filename = $dir . 'xlsx_files/' . $filename;
+
+my $ignore_members  = [];
+my $ignore_elements = {};
+
+###############################################################################
+#
+# Declare the shared variable $cleanup_lock_counter.
+#
+my $cleanup_lock_counter = 0;
+threads::shared::share( \$cleanup_lock_counter );
+
+###############################################################################
+#
+# Generate workbooks in multiple concurrent threads.
+#
+foreach my $threadNo ( 1 .. $numThreads ) {
+    threads->create( make_runnable( $dir . "Thread $threadNo" ) );
+}
+$_->join foreach threads->list();
+
+###############################################################################
+#
+# Compare the generated and existing Excel files, and cleanup.
+#
+foreach my $threadNo ( 1 .. $numThreads ) {
+    foreach my $bookNo ( 1 .. $numBooksPerThread ) {
+        my $got_filename = $dir . "Thread $threadNo book $bookNo.xlsx";
+
+        my ( $got, $expected, $caption ) = _compare_xlsx_files(
+
+            $got_filename, $exp_filename,
+            $ignore_members,
+            $ignore_elements,
+        );
+
+        _is_deep_diff( $got, $expected, $caption );
+
+        unlink $got_filename;
+
+    }
+}
+
+###############################################################################
+#
+# Create the runnable for a thread to generate workbook files
+# and destroy its temporary files in a controlled manner.
+#
+sub make_runnable {
+    my ($filenamePrefix) = @_;
+    sub {
+        my @workbookObjects;
+
+        # Make workbooks, maintaining the shared variable $cleanup_lock_counter.
+        foreach my $bookNo ( 1 .. $numBooksPerThread ) {
+            {    # increment the shared variable $cleanup_lock_counter.
+                lock $cleanup_lock_counter;
+                ++$cleanup_lock_counter;
+            }
+            push @workbookObjects,
+              make_workbook("$filenamePrefix book $bookNo.xlsx");
+            {    # decrement the shared variable $cleanup_lock_counter.
+                lock $cleanup_lock_counter;
+                --$cleanup_lock_counter;
+                threads::shared::cond_signal( \$cleanup_lock_counter );
+            }
+        }
+
+        # Wait for the shared variable $cleanup_lock_counter to be zero.
+        lock $cleanup_lock_counter;
+        threads::shared::cond_wait( \$cleanup_lock_counter )
+          while $cleanup_lock_counter > 0;
+
+        # Destruction of temporary files associated with each workbook object.
+        $_->DESTROY foreach grep { defined $_; } @workbookObjects;
+        threads::shared::cond_signal( \$cleanup_lock_counter );
+
+    };
+}
+
+###############################################################################
+#
+# Create a simple Excel::Writer::XLSX file which should match simple01.xlsx.
+#
+sub make_workbook {
+    my ($filename) = @_;
+
+    my $workbook = Excel::Writer::XLSX->new($filename) or return;
+    my $worksheet = $workbook->add_worksheet();
+
+    $worksheet->write( 'A1', 'Hello' );
+    $worksheet->write( 'A2', 123 );
+
+    # Generate file.
+    $workbook->close();
+
+    # Return workbook object to caller, to control clean-up of temporary files.
+    $workbook;
+
+}
+
+__END__


### PR DESCRIPTION
This adds two commits to those in PR #261 to use File::Path::Tiny to remove the temp files.  They are also rebased on current main.

Passes the tests added by @f20


An alternate approach would be to use File::Find to list all the files under the temp dir, sorted by depth, and then delete them using unlink.  


There are two new warnings related to tainting. I'm not sure how important they are.  

```
t/regression/taint01.t ................................ 1/1     (in cleanup) Insecure dependency in unlink while running with -T switch at C:/perls/5.40.0.1_PDL/perl/site/lib/File/Path/Tiny.pm line 74.
t/regression/taint01.t ................................ ok
t/regression/taint02.t ................................ 1/1     (in cleanup) Insecure dependency in unlink while running with -T switch at C:/perls/5.40.0.1_PDL/perl/site/lib/File/Path/Tiny.pm line 74.
t/regression/taint02.t ................................ ok
```

As a side note, I wonder if the temp dirs should have a prefix such as ```ewxlsx``` so they are easier to identify on the temp dir.  I can add that if it is considered useful, or open a separate PR.

